### PR TITLE
Update the base image to registry.access.redhat.com/ubi9/nodejs20:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-20:latest AS build-image
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS build-image
 
 ### BEGIN REMOTE SOURCE
 # Use the COPY instruction only inside the REMOTE SOURCE block
@@ -30,7 +30,7 @@ RUN NEWKEY=`/usr/src/app/jwt-key-gen.sh` && sed -i "s/^SECRET_ACCESS_TOKEN=.*/SE
 ## Gather productization dependencies
 RUN yarn install --network-timeout 1000000 --modules-folder node_modules_prod --production
 
-FROM registry.access.redhat.com/ubi8/nodejs-20-minimal:latest
+FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:latest
 
 COPY --from=build-image /usr/src/app/dist /usr/share/amq-spp/dist
 COPY --from=build-image /usr/src/app/.env /usr/share/amq-spp/.env


### PR DESCRIPTION
Currently in our projects the base image of AMQ Broker containers and operator images have been updated to `RHEL9` for FIPS. It makes sense to do the same for the `jolokia-api-server` to ensure long-term support, security updates, and compatibility with the latest environments.

fixes: [#6](https://github.com/arkmq-org/activemq-artemis-jolokia-api-server/issues/6)