### PR TITLE
[NO-ISSUE] compatibility with all cert-managers

### DIFF
--- a/undeploy.sh
+++ b/undeploy.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env sh
 
-oc kustomize deploy | oc delete -f -
+# find the cert-manager operator namespace, if this can't be retrived there's no
+# possibility to proceed
+certManagerNamespace=$(oc get Subscriptions --all-namespaces -ojson | jq -r '.items[] | select(.spec.name == "cert-manager") | .metadata.namespace')
+if test -z "$certManagerNamespace"
+then
+  certManagerNamespace=$(oc get Subscriptions --all-namespaces -ojson | jq -r '.items[] | select(.spec.name == "openshift-cert-manager-operator") | .metadata.namespace')
+  if test -z "$certManagerNamespace"
+  then
+    echo "cert-manager's namespace can't be determined, defaulting to default namespace"
+    certManagerNamespace="openshift-operators"
+  fi
+fi
+echo "cert-manager's namespace: $certManagerNamespace"
+oc kustomize deploy \
+    | sed "s|namespace: openshift-operators|namespace: ${certManagerNamespace}|" \
+    | oc delete -f -
 oc delete secret jolokia-api-server-selfsigned-ca-cert-secret -n activemq-artemis-jolokia-api-server
-oc delete secret jolokia-api-server-selfsigned-ca-cert-secret -n openshift-operators
+oc delete secret jolokia-api-server-selfsigned-ca-cert-secret -n ${certManagerNamespace}


### PR DESCRIPTION
There's two variant of cert-manager available on the openshift operatorHub, one for upstream (the community one) and one for downstream built by Red Hat. Depending on which one the cluster administrator did chose, the deploy and undeploy script must adapt to it. This is what this PR brings in to the table. Now the scripts are looking first if the upstream version is installed, and then if the downstream version is there. The deploy script will fail if no cert-manager are present on the cluster.