### PR TITLE
[NO-ISSUE] correctly increase the version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,11 +48,10 @@ jobs:
           VERSION_MINOR=${VERSION_MINOR/\*/${CURRENT_VERSION_MINOR}} && VERSION_MINOR=${VERSION_MINOR/+/$((CURRENT_VERSION_MINOR+1))}
           VERSION_PATCH=${VERSION_PATCH/\*/${CURRENT_VERSION_PATCH}} && VERSION_PATCH=${VERSION_PATCH/+/$((CURRENT_VERSION_PATCH+1))}
           VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
-          PACKAGE_JSON_CONTENTS=$(jq '.version="'"$VERSION"'" \
-          | .consolePlugin.version="'"$VERSION"'" \
-          | ._id="activemq-artemis-jolokia-api-server@'$VERSION'"' package.json) \
-          && echo -E "${PACKAGE_JSON_CONTENTS}" > package.json && unset PACKAGE_JSON_CONTENTS
           sed -i "s~^LABEL version=.*~LABEL version=\"${VERSION}\"~g" Dockerfile
+          sed -i "s~^  \"version\":.*\"~  \"version\": \"${VERSION}\"~g" package.json
+          sed -i "s~^    \"version\":.*\"~    \"version\": \"${VERSION}\"~g" package.json
+          sed -i "s~activemq-artemis-jolokia-api-server@.*~activemq-artemis-jolokia-api-server@${VERSION}\",~g" package.json
           git commit --all --message "Update version to ${VERSION}" || echo "nothing to commit"
 
       - name: Push commits

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activemq-artemis-jolokia-api-server",
-  "version": "0.1.2",
+  "version": "0.2.3",
   "private": true,
   "homepage": "https://github.com/arkmq-org/activemq-artemis-jolokia-api-server#readme",
   "bugs": {
@@ -70,7 +70,7 @@
     "yaml": "^2.4.5"
   },
   "readme": "README.md",
-  "_id": "activemq-artemis-jolokia-api-server@0.1.2",
+  "_id": "activemq-artemis-jolokia-api-server@0.2.3",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {
     "base-64": "^1.0.0",


### PR DESCRIPTION
The update script was suffering from a bug where the version number wasn't updated correctly. Leading to it always creating a 0.1.2 release tag upstream.