### PR TITLE
[NO-ISSUE] override certManager namespace

### DIFF
--- a/undeploy.sh
+++ b/undeploy.sh
@@ -1,15 +1,49 @@
 #!/usr/bin/env sh
 
-# find the cert-manager operator namespace, if this can't be retrived there's no
-# possibility to proceed
-certManagerNamespace=$(oc get Subscriptions --all-namespaces -ojson | jq -r '.items[] | select(.spec.name == "cert-manager") | .metadata.namespace')
+function printUsage() {
+  echo "${SCRIPT_NAME}: Deleting the jolokia api server from openshift"
+  echo "Usage:"
+  echo "  ./${SCRIPT_NAME} -i|--image <image url>"
+  echo "Options: "
+  echo "  -c|--certManagerNamespace  give the namespace cert manager is installed in, will search for it in the Subscriptions otherwise"
+  echo "  -h|--help   Print this message."
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      printUsage
+      exit 0
+      ;;
+    -c|--certManagerNamespace)
+      certManagerNamespace="$2"
+      shift
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      printUsage
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
+# if the user has overridden the certManagerNamespace don't try to search for it
 if test -z "$certManagerNamespace"
-then
-  certManagerNamespace=$(oc get Subscriptions --all-namespaces -ojson | jq -r '.items[] | select(.spec.name == "openshift-cert-manager-operator") | .metadata.namespace')
+  then
+  # find the cert-manager operator namespace, if this can't be retrived there's no
+  # possibility to proceed
+  certManagerNamespace=$(oc get Subscriptions --all-namespaces -ojson | jq -r '.items[] | select(.spec.name == "cert-manager") | .metadata.namespace')
   if test -z "$certManagerNamespace"
   then
-    echo "cert-manager's namespace can't be determined, defaulting to default namespace"
-    certManagerNamespace="openshift-operators"
+    certManagerNamespace=$(oc get Subscriptions --all-namespaces -ojson | jq -r '.items[] | select(.spec.name == "openshift-cert-manager-operator") | .metadata.namespace')
+    if test -z "$certManagerNamespace"
+    then
+      echo "Error: cert-manager's namespace can't be determined"
+      exit 1
+    fi
   fi
 fi
 echo "cert-manager's namespace: $certManagerNamespace"


### PR DESCRIPTION
Add the ability to override the cert manager namespace if the user doesn't want to rely on the auto detect in the subscriptions. Can be very useful when relying on helm charts instead of OLM to install cert manager.